### PR TITLE
Shorten URL when node is missing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,14 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "redirects": [
+    {
+      "source": "/rad(.*)",
+      "destination": "/nodes/seed.radicle.garden/rad$1"
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,10 @@
       "destination": "/nodes/seed.radicle.garden/rad$1/issues/$2"
     },
     {
+      "source": "/rad([^/]+)/p/(.+)",
+      "destination": "/nodes/seed.radicle.garden/rad$1/patches/$2"
+    },
+    {
       "source": "/rad(.*)",
       "destination": "/nodes/seed.radicle.garden/rad$1"
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,10 @@
 {
   "redirects": [
     {
+      "source": "/rad([^/]+)/i/(.+)",
+      "destination": "/nodes/seed.radicle.garden/rad$1/issues/$2"
+    },
+    {
       "source": "/rad(.*)",
       "destination": "/nodes/seed.radicle.garden/rad$1"
     }


### PR DESCRIPTION
Shorten URL by:

Omitting the nodes and using `seed.radicle.garden` as default node.

https://git.chen.so/nodes/seed.radicle.garden/rad:z31RADNa8uNMWFep88bhenzxTR1Ei/issues/97e1570ed0e9e4380a955bc440cbe21f6610cfda

=>

https://git.chen.so/rad:z31RADNa8uNMWFep88bhenzxTR1Ei/issues/97e1570ed0e9e4380a955bc440cbe21f6610cfda

— 

## Additional considerations:
- Randomly pick a node from a preset of default nodes.
- `node` param (`seed.radicle.garden`) could be passed in the request header instead of the URL path, and when missing default node is used.
- ~~`repo` param (`rad:z31RADNa8uNMWFep88bhenzxTR1Ei`) could be passed in the request header instead of the URL path to further shorten URL, and when missing default to the most recently used repo, or to a build-time ENVIRONMENT variable.~~
- `NAMED_REPO_TABLE` a runtime hash map table with pre-defined list of slugs mapping to their long full `rad:z31RADNa8uNMWFep88bhenzxTR1Ei` form, stored in a CSV file or parsed from a build-time ENVIRONMENT variable.
- Shorthand first 7 letter/numbers to reference issues & patches.
- Shorthand `/r/repo-name` for repos, `/i/xxxxxxx` for issues and `/p/xxxxxxx` for patches. Final look: https://git.chen.so/r/repo-name/i/97e1570 => https://git.chen.so/nodes/seed.radicle.garden/rad:z31RADNa8uNMWFep88bhenzxTR1Ei/issues/97e1570ed0e9e4380a955bc440cbe21f6610cfda


---

- Issue: [3869a6c9cfaa723398b7d4234aa079817fb78d27](https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/i/3869a6c9cfaa723398b7d4234aa079817fb78d27)
- Patch: [b3cfacab36fa38609b943fed9d9d84738fa13e68](https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/p/b3cfacab36fa38609b943fed9d9d84738fa13e68)
- https://github.com/Chen-Software/radicle-web-ui/pull/2