### PR TITLE
`nodes` omissible in URL defaulting to preferred seeds

### DIFF
--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -182,6 +182,18 @@ function urlToRoute(url: URL): Route | null {
   const segments = url.pathname.substring(1).split("/");
 
   const resource = segments.shift();
+
+  if (resource?.startsWith("rad:")) {
+    return resolveRepoRoute(
+      config.preferredSeeds[
+      Math.random() * config.preferredSeeds.length | 0
+      ],
+      resource,
+      segments,
+      url.search
+    );
+  }
+
   switch (resource) {
     case "nodes":
     case "seeds": {


### PR DESCRIPTION
Shorten URL by:

Omitting the nodes and randomly picking a node from `preferredSeeds` as default node.

https://git.chen.so/nodes/seed.radicle.garden/rad:z31RADNa8uNMWFep88bhenzxTR1Ei/issues/97e1570ed0e9e4380a955bc440cbe21f6610cfda

=>

https://git.chen.so/rad:z31RADNa8uNMWFep88bhenzxTR1Ei/issues/97e1570ed0e9e4380a955bc440cbe21f6610cfda

— 

## Additional considerations:
- `node` param (`seed.radicle.garden`) could be passed in the request header instead of the URL path, and when missing default node is used.
- ~~`repo` param (`rad:z31RADNa8uNMWFep88bhenzxTR1Ei`) could be passed in the request header instead of the URL path to further shorten URL, and when missing default to the most recently used repo, or to a build-time ENVIRONMENT variable.~~
- `NAMED_REPO_TABLE` a runtime hash map table with pre-defined list of slugs mapping to their long full `rad:z31RADNa8uNMWFep88bhenzxTR1Ei` form, stored in a CSV file or parsed from a build-time ENVIRONMENT variable.
- Shorthand first 7 letter/numbers to reference issues & patches.
- Shorthand `/r/repo-name` for repos, `/i/xxxxxxx` for issues and `/p/xxxxxxx` for patches. Final look: https://git.chen.so/r/repo-name/i/97e1570 => https://git.chen.so/nodes/seed.radicle.garden/rad:z31RADNa8uNMWFep88bhenzxTR1Ei/issues/97e1570ed0e9e4380a955bc440cbe21f6610cfda


---

- Issue: https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/i/3869a6c9cfaa723398b7d4234aa079817fb78d27
- Patch: https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/p/1f2b6f028e145e692e6337e2c76e837d9da06378
- https://github.com/Chen-Software/radicle-web-ui/pull/3