### PR TITLE
Hide node from path in links

### DIFF
--- a/http-client/lib/fetcher.ts
+++ b/http-client/lib/fetcher.ts
@@ -10,6 +10,7 @@ export interface BaseUrl {
   hostname: string;
   port: number;
   scheme: string;
+  hidden?: boolean;
 }
 
 // Error that is thrown by `Fetcher` methods.

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -185,9 +185,12 @@ function urlToRoute(url: URL): Route | null {
 
   if (resource?.startsWith("rad:")) {
     return resolveRepoRoute(
-      config.preferredSeeds[
-      Math.random() * config.preferredSeeds.length | 0
-      ],
+      {
+        ...config.preferredSeeds[
+        Math.random() * config.preferredSeeds.length | 0
+        ],
+        hidden: true,
+      },
       resource,
       segments,
       url.search

--- a/src/views/repos/router.ts
+++ b/src/views/repos/router.ts
@@ -930,7 +930,7 @@ export function repoRouteToPath(route: RepoRoute): string {
 
   const pathSegments =
     route.node.hidden ?
-      [route.repo] :
+      ["", route.repo] :
       [node, route.repo];
 
   if (route.resource === "repo.source") {

--- a/src/views/repos/router.ts
+++ b/src/views/repos/router.ts
@@ -928,7 +928,10 @@ function resolvePatchesRoute(
 export function repoRouteToPath(route: RepoRoute): string {
   const node = nodePath(route.node);
 
-  const pathSegments = [node, route.repo];
+  const pathSegments =
+    route.node.hidden ?
+      [route.repo] :
+      [node, route.repo];
 
   if (route.resource === "repo.source") {
     if (route.peer) {


### PR DESCRIPTION
Add `hidden` attribute in `BaseUrl` and hide the `node` param accordingly.

---

- Issue: https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/i/3869a6c9cfaa723398b7d4234aa079817fb78d27
- Patch: https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/p/fc6fbcc71880b519c4b617f38f2bd6b25cef2984
https://github.com/Chen-Software/radicle-web-ui/pull/6