### PR TITLE
Update domain name to `git.chen.so`

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,6 @@
 {
   "nodes": {
-    "fallbackPublicExplorer": "https://app.radicle.xyz/nodes/$host/$rid$path",
+    "fallbackPublicExplorer": "https://git.chen.so/nodes/$host/$rid$path",
     "requiredApiVersion": "~0.18.0",
     "defaultHttpdPort": 443,
     "defaultHttpdScheme": "https"

--- a/index.html
+++ b/index.html
@@ -8,22 +8,22 @@
     <meta name="name" content="Radicle Explorer" />
     <meta name="description" content="Explore the Radicle network" />
 
-    <meta property="og:url" content="https://app.radicle.xyz" />
+    <meta property="og:url" content="https://git.chen.so" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Radicle Explorer" />
     <meta property="og:description" content="Explore the Radicle network" />
     <meta
       property="og:image"
-      content="https://app.radicle.xyz/images/radicle-og-853x853-624f.png" />
+      content="https://git.chen.so/images/radicle-og-853x853-624f.png" />
 
     <meta name="twitter:card" content="summary" />
-    <meta property="twitter:domain" content="app.radicle.xyz" />
-    <meta property="twitter:url" content="https://app.radicle.xyz" />
+    <meta property="twitter:domain" content="git.chen.so" />
+    <meta property="twitter:url" content="https://git.chen.so" />
     <meta name="twitter:title" content="Radicle Explorer" />
     <meta name="twitter:description" content="Explore the Radicle network" />
     <meta
       name="twitter:image"
-      content="https://app.radicle.xyz/images/radicle-og-853x853-624f.png" />
+      content="https://git.chen.so/images/radicle-og-853x853-624f.png" />
 
     <link
       rel="preload"

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -635,7 +635,7 @@ export const gitOptions = {
   },
 };
 export const defaultConfig: Config = {
-  publicExplorer: "https://app.radicle.xyz/nodes/$host/$rid$path",
+  publicExplorer: "https://git.chen.so/nodes/$host/$rid$path",
   preferredSeeds: [],
   web: {
     pinned: {

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -73,8 +73,8 @@ describe("String Assertions", () => {
   });
 
   test.each([
-    { url: "https://app.radicle.xyz", expected: true },
-    { url: "http://app.radicle.xyz", expected: true },
+    { url: "https://git.chen.so", expected: true },
+    { url: "http://git.chen.so", expected: true },
     { url: "http://app", expected: true },
     { url: "://app", expected: false },
     { url: "//app", expected: false },
@@ -122,7 +122,7 @@ describe("Path Manipulation", () => {
     {
       imagePath: "/assets/images/tux.png",
       base: "/",
-      origin: "https://app.radicle.xyz",
+      origin: "https://git.chen.so",
       expected: "assets/images/tux.png",
     },
     {
@@ -134,7 +134,7 @@ describe("Path Manipulation", () => {
     {
       imagePath: "assets/images/tux.png",
       base: "/",
-      origin: "https://app.radicle.xyz",
+      origin: "https://git.chen.so",
       expected: "assets/images/tux.png",
     },
     {


### PR DESCRIPTION
Update domain name to `git.chen.so`

---
- Issue: https://git.chen.so/rad:z3kb9edS8JXMrR8oqoPguxcSzDyVJ/i/0d684e143e57be0888519510bda51d6f9a4562ac
- Patch: https://git.chen.so/rad:z3kb9edS8JXMrR8oqoPguxcSzDyVJ/p/35545289ed1ce472d78f01be2bf151997f3aaef9
- https://github.com/Chen-Software/radicle-ui/pull/8