### PR TITLE
Named Repositories

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -26,5 +26,8 @@
       "port": 443,
       "scheme": "https"
     }
-  ]
+  ],
+  "namedRepositories": {
+    "radicle-ui": "rad:z3kb9edS8JXMrR8oqoPguxcSzDyVJ"
+  }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -28,6 +28,7 @@
     }
   ],
   "namedRepositories": {
+    "default": "rad:z3kb9edS8JXMrR8oqoPguxcSzDyVJ",
     "radicle-ui": "rad:z3kb9edS8JXMrR8oqoPguxcSzDyVJ"
   }
 }

--- a/module.d.ts
+++ b/module.d.ts
@@ -14,6 +14,7 @@ declare module "virtual:*" {
     reactions: string[];
     supportWebsite: string;
     preferredSeeds: BaseUrl[];
+    namedRepositories: Record<string, string>;
   };
 
   export default config;

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -181,7 +181,22 @@ function extractBaseUrl(hostAndPort: string): BaseUrl {
 function urlToRoute(url: URL): Route | null {
   const segments = url.pathname.substring(1).split("/");
 
-  const resource = segments.shift();
+  const resource = segments.shift() || "default";
+
+  if (Object.keys(config.namedRepositories).includes(resource)) {
+    return resolveRepoRoute(
+      {
+        ...config.preferredSeeds[
+        Math.random() * config.preferredSeeds.length | 0
+        ],
+        hidden: true,
+      },
+      config.namedRepositories[resource],
+      segments,
+      url.search
+    );
+  }
+
   switch (resource) {
     case "nodes":
     case "seeds": {


### PR DESCRIPTION
Support named repositories:

- `namedRepositories` a runtime hash map table with pre-defined list of slugs mapping to their long full `rad:z31RADNa8uNMWFep88bhenzxTR1Ei` form, stored in a `json` config variable.

— 
- Issue: https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/i/0f3d09535210d92702986939f83572baa64495fa
- Related issue: https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/i/3869a6c9cfaa723398b7d4234aa079817fb78d27
- Patch: https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/p/4690d86d2f2842fb364d2aef1f167e5e72786f12
- https://github.com/Chen-Software/radicle-ui/pull/9