### PR TITLE
Remove restrictive seed node `seed.radicle.xyz`

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -17,11 +17,6 @@
       "scheme": "https"
     },
     {
-      "hostname": "seed.radicle.xyz",
-      "port": 443,
-      "scheme": "https"
-    },
-    {
       "hostname": "seed.radicle.garden",
       "port": 443,
       "scheme": "https"


### PR DESCRIPTION
Remove restrictive seed node `seed.radicle.xyz` from preferred seeds

—
- Issue: https://git.chen.so/radicle-ui/issues/917c401a2cdce24fd69450d525cdb282ab3638be
- Related issue: https://git.chen.so/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/issues/3869a6c9cfaa723398b7d4234aa079817fb78d27
- Patch: https://git.chen.so/radicle-ui/patches/38acad32c0bef1986769532fc52fdf65ee112745
- https://github.com/Chen-Software/radicle-ui/pull/11